### PR TITLE
Reintroduce 1 minimum machine for Fly deployment

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,7 +13,7 @@ primary_region = 'sjc'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
It was set to 1 in PR #36 but rolled back again to 0 in PR #38.
However, I still observe a very noticeable 5-second cold start. So let's keep it to 1 for the time being.