### PR TITLE
refactor: exclude Wayfair brand

### DIFF
--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -6,7 +6,6 @@ import { TraitsSelector } from './TraitsSelector.js';
 import { ImageStyleSelector } from './ImageStyleSelector.js';
 import type { BrandConfig } from '../modules/Config.js';
 import type { PurchaseHistory } from '../modules/DataTransformSchema.js';
-import { ModelSelector } from './ModelSelector.js';
 
 type SidebarProps = {
   isOpen: boolean;

--- a/src/client/pages/DataPortrait.tsx
+++ b/src/client/pages/DataPortrait.tsx
@@ -29,6 +29,10 @@ const BRANDS: Array<BrandConfig> = [
   goodreadsConfig,
 ];
 
+// NOTE: temporarily excluded wayfair brand due to this issue:
+// https://github.com/mcp-getgather/private-issues/issues/76
+const EXCLUDED_BRANDS: Array<string> = [wayfairConfig.brand_id];
+
 // Sample data for demo purposes
 const sampleOrders: PurchaseHistory[] = [
   {
@@ -278,7 +282,9 @@ export function DataPortrait() {
       <Sidebar
         isOpen={isSidebarOpen}
         onClose={() => setIsSidebarOpen(false)}
-        brands={BRANDS}
+        brands={BRANDS.filter(
+          (brand) => !EXCLUDED_BRANDS.includes(brand.brand_id)
+        )}
         connectedBrands={connectedBrands}
         selectedGender={selectedGender}
         selectedTraits={selectedTraits}


### PR DESCRIPTION
Temporarily excludes Wayfair brand from the DataPortrait component due to a known issue

