### PR TITLE
fix: change wayfair tool

### DIFF
--- a/src/server/handlers/mcp-handler.ts
+++ b/src/server/handlers/mcp-handler.ts
@@ -12,7 +12,7 @@ const tools: Record<string, string[]> = {
     'officedepot_get_order_history',
     'officedepot_get_order_history_details',
   ],
-  wayfair: ['wayfair_dpage_get_order_history'],
+  wayfair: ['wayfair_get_order_history'],
   goodreads: ['goodreads_get_book_list'],
 };
 


### PR DESCRIPTION
Change wayfair tool from using `dpage_get_order_history` to `get_order_history` as we will remove all wayfair's tool with `dpage_` prefix.

https://github.com/mcp-getgather/mcp-getgather/blob/d6be0460fcce3d68fafbca33489efff6501c3935/getgather/mcp/wayfair.py#L10-L25