### PR TITLE
feat: support both Google GenAI and Portkey providers

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,10 +4,18 @@ GETGATHER_URL=
 MAXMIND_ACCOUNT_ID=
 MAXMIND_LICENSE_KEY=
 
-TOGETHER_API_KEY=
+# Image Generation Providers (choose one or both)
+# Provider selection priority: PORTKEY_API_KEY > GEMINI_API_KEY
+# - If PORTKEY_API_KEY is set, uses Portkey
+# - If only GEMINI_API_KEY is set, uses Google GenAI
+# - If both are set, Portkey is prioritized
+PORTKEY_API_KEY=
 GEMINI_API_KEY=
+
 SENTRY_DSN=
 
+# Google Cloud Storage (optional)
+# If not configured, images will be stored locally in public/ directory
 GCS_BUCKET_NAME=
 GCS_PROJECT_ID=
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Data Portrait is a web app that transforms your shopping and reading history int
 
 - **Frontend:** React (Vite), TypeScript, Tailwind CSS.
 - **Backend:** Express.js, geolocation via MaxMind, reverse proxy to GetGather API.
-- **AI Models:** Google Gemini, FLUX (via Together AI).
+- **AI Models:** Google Gemini via Portkey or direct Google GenAI.
+- **Storage:** Google Cloud Storage (optional) or local filesystem.
 - **Data Model:** Purchases include brand, order date, products, images, etc.
 
 ## Configuration
@@ -48,8 +49,17 @@ MAXMIND_ACCOUNT_ID=your_maxmind_account_id
 MAXMIND_LICENSE_KEY=your_maxmind_license_key
 
 # AI Providers (required for image generation)
-TOGETHER_API_KEY=your_together_ai_key
+# Image generation provider is automatically selected based on API key availability:
+# - If PORTKEY_API_KEY is set, uses Portkey (recommended for production)
+# - If only GEMINI_API_KEY is set, uses Google GenAI directly
+# - Both keys can be set; Portkey will be prioritized
+PORTKEY_API_KEY=your_portkey_api_key
 GEMINI_API_KEY=your_gemini_api_key
+
+# Google Cloud Storage (optional, for cloud image storage)
+# If not configured, images are stored locally in the public/ directory
+GCS_BUCKET_NAME=data-portrait-imagegen
+GCS_PROJECT_ID=your_gcp_project_id
 ```
 
 ## Development
@@ -61,7 +71,7 @@ Use Docker or Podman to pull the container image and run it:
 ```bash
 docker run -p 3000:3000 \
   -e GETGATHER_URL=your_local_mcp_getgather_url \
-  -e GEMINI_API_KEY=your_gemini_key \
+  -e PORTKEY_API_KEY=your_portkey_key \
   ghcr.io/mcp-getgather/data-portrait:latest
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "react-select": "^5.10.2",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10",
-        "together-ai": "^0.16.0",
         "tsx": "^4.19.3",
         "tw-animate-css": "^1.3.8",
         "typescript": "^5.8.3",
@@ -3370,34 +3369,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@types/node-int64": {
-      "version": "0.4.32",
-      "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.32.tgz",
-      "integrity": "sha512-xf/JsSlnXQ+mzvc0IpXemcrO4BrCfpgNpMco+GLcXkFk01k/gW9lGJu+Vof0ZSvHK6DsHJDPSbjFPs36QkWXqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/parquetjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/parquetjs/-/parquetjs-0.10.6.tgz",
-      "integrity": "sha512-ZCsD6j97YD0mGU8/VnVs3NjORXa7zeHvqlpJpCqy4jU8a1O21dalL+MFn9QNbdEfy8rszR1N7NHeT7/LdtHf+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node-int64": "*"
-      }
-    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -3422,15 +3393,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/pg": "*"
-      }
-    },
-    "node_modules/@types/progress-stream": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/progress-stream/-/progress-stream-2.0.5.tgz",
-      "integrity": "sha512-5YNriuEZkHlFHHepLIaxzq3atGeav1qCTGzB74HKWpo66qjfostF+rHc785YYYHeBytve8ZG3ejg42jEIfXNiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -4026,17 +3988,6 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
-    "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -4100,13 +4051,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha512-u4cBQNepWxYA55FunZSM7wMi55yQaN0otnhhilNoWHq0MfOfJeQx0v0mRRpolGOExPjZcl6FtB0BB8Xkb88F0g==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -4150,15 +4094,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/brotli": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
-      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.1.2"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
@@ -4190,15 +4125,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.6.19"
       }
     },
     "node_modules/buffer": {
@@ -4545,12 +4471,6 @@
       "engines": {
         "node": ">=6.6.0"
       }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -5410,62 +5330,6 @@
         }
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5977,12 +5841,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/int53": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
-      "integrity": "sha512-a5jlKftS7HUOhkUyYD7j2sJ/ZnvWiNlZS1ldR+g1ifQ+/UuZXIE+YTc/lK1qGj/GwAU5F8Z0e1eVq2t1J5Ob2g==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6092,12 +5950,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6533,17 +6385,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/lzo": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/lzo/-/lzo-0.4.11.tgz",
-      "integrity": "sha512-apQHNoW2Alg72FMqaC/7pn03I7umdgSVFt2KRkCXXils4Z9u3QBh1uOtl2O5WmZIDLd9g6Lu4lIdOLmiSTFVCQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bindings": "~1.2.1"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -6761,26 +6602,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -6800,12 +6621,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -6885,14 +6700,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/object-stream/-/object-stream-0.0.1.tgz",
-      "integrity": "sha512-+NPJnRvX9RDMRY9mOWOo/NDppBjbZhXirNNSu2IBnuNboClC9h1ZGHXgHBLDbJMHsxeJDq922aVmG5xs24a/cA==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/on-finished": {
@@ -7001,27 +6808,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parquetjs": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/parquetjs/-/parquetjs-0.11.2.tgz",
-      "integrity": "sha512-Y6FOc3Oi2AxY4TzJPz7fhICCR8tQNL3p+2xGQoUAMbmlJBR7+JJmMrwuyMjIpDiM7G8Wj/8oqOH4UDUmu4I5ZA==",
-      "license": "MIT",
-      "dependencies": {
-        "brotli": "^1.3.0",
-        "bson": "^1.0.4",
-        "int53": "^0.2.4",
-        "object-stream": "0.0.1",
-        "snappyjs": "^0.6.0",
-        "thrift": "^0.11.0",
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=7.6"
-      },
-      "optionalDependencies": {
-        "lzo": "^0.4.0"
       }
     },
     "node_modules/parse-json": {
@@ -7319,22 +7105,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
-    "node_modules/progress-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
-      "integrity": "sha512-xJwOWR46jcXUq6EH9yYyqp+I52skPySOeHfkxOZ2IY1AiBi/sFJhbhAKHoV3OTw/omQ45KTio9215dRJ2Yxd3Q==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "speedometer": "~1.0.0",
-        "through2": "~2.0.3"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7359,12 +7129,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -7378,17 +7142,6 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qs": {
@@ -7633,27 +7386,6 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -8077,12 +7809,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/snappyjs": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.6.1.tgz",
-      "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg==",
-      "license": "MIT"
-    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -8100,12 +7826,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/speedometer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
-      "integrity": "sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==",
-      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -8327,30 +8047,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/thrift": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.11.0.tgz",
-      "integrity": "sha512-UpsBhOC45a45TpeHOXE4wwYwL8uD2apbHTbtBvkwtUU4dNwCjC7DpQTjw2Q6eIdfNtw+dKthdwq94uLXTJPfFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "node-int64": "^0.4.0",
-        "q": "^1.5.0",
-        "ws": ">= 2.2.3"
-      },
-      "engines": {
-        "node": ">= 4.1.0"
-      }
-    },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
     "node_modules/tiny-lru": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.3.2.tgz",
@@ -8413,41 +8109,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/together-ai": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/together-ai/-/together-ai-0.16.0.tgz",
-      "integrity": "sha512-k8vrcjNKlaklf9lFkIeNzH/M/xt2Ykt84/RruK+AGMu8G/+M2Kx4kHyjx6kgSgt8wpgi3JvvzZ6fg7Y3FORuFA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "@types/parquetjs": "^0.10.6",
-        "@types/progress-stream": "^2.0.5",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "axios": "^1.7.7",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "parquetjs": "^0.11.2",
-        "progress-stream": "^2.0.0"
-      }
-    },
-    "node_modules/together-ai/node_modules/@types/node": {
-      "version": "18.19.112",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
-      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/together-ai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -8741,12 +8402,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
-      "license": "MIT"
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -8854,15 +8509,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "react-select": "^5.10.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
-    "together-ai": "^0.16.0",
     "tsx": "^4.19.3",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5.8.3",

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -8,7 +8,6 @@ export const settings = {
   GETGATHER_URL: process.env.GETGATHER_URL || '',
   MAXMIND_ACCOUNT_ID: process.env.MAXMIND_ACCOUNT_ID || '',
   MAXMIND_LICENSE_KEY: process.env.MAXMIND_LICENSE_KEY || '',
-  TOGETHER_API_KEY: process.env.TOGETHER_API_KEY || '',
   GEMINI_API_KEY: process.env.GEMINI_API_KEY || '',
   PORTKEY_API_KEY: process.env.PORTKEY_API_KEY || '',
   SENTRY_DSN: process.env.SENTRY_DSN || '',


### PR DESCRIPTION
close https://github.com/remotebrowser/data-portrait/issues/74

## Summary
- Added support for both Google GenAI and Portkey as image generation providers
- Implemented automatic provider selection based on API key availability (Portkey prioritized)
- Removed Together AI dependency and references
- Improved GCS configuration documentation

## Provider Selection Logic
- If `PORTKEY_API_KEY` is set → uses Portkey
- If only `GEMINI_API_KEY` is set → uses Google GenAI directly
- If neither is set → throws clear error

## Tests

Using portkey

<img width="1920" height="971" alt="image" src="https://github.com/user-attachments/assets/05d05889-7a94-4940-9f4d-868cd8d59662" />


Using gemini

<img width="1904" height="930" alt="image" src="https://github.com/user-attachments/assets/b9fe64c5-a737-4d21-8b2e-d0ff220d36c2" />
