### PR TITLE
fix: correctly serialize and parse imageStyle in portrait generation

### DIFF
--- a/src/client/pages/DataPortrait.tsx
+++ b/src/client/pages/DataPortrait.tsx
@@ -176,7 +176,7 @@ export function DataPortrait() {
           ? (() => {
               const formData = new FormData();
               formData.append('image', uploadedImage);
-              formData.append('imageStyle', JSON.stringify(selectedImageStyle));
+              formData.append('imageStyle', selectedImageStyle.join(','));
               formData.append('gender', selectedGender);
               formData.append('traits', selectedTraits.join(','));
               formData.append('purchaseData', JSON.stringify(orders));

--- a/src/server/handlers/portrait-handler.ts
+++ b/src/server/handlers/portrait-handler.ts
@@ -11,6 +11,13 @@ export const handlePortraitGeneration = async (
 
   try {
     const { imageStyle, gender, traits, purchaseData } = req.body;
+
+    const parsedImageStyle = Array.isArray(imageStyle)
+      ? imageStyle
+      : typeof imageStyle === 'string'
+        ? imageStyle.split(',').map((s) => s.trim())
+        : [];
+
     const uploadedFile = req.file;
 
     if (uploadedFile) {
@@ -37,7 +44,7 @@ export const handlePortraitGeneration = async (
         : [];
 
     const prompt = await promptService.buildPrompt({
-      imageStyle,
+      imageStyle: parsedImageStyle,
       gender,
       traits: parsedTraits,
       purchaseData: parsedPurchaseData,


### PR DESCRIPTION
## Summary

- Changed frontend to send imageStyle as comma-separated values instead of JSON
- Added backend parsing for imageStyle to handle comma-separated strings
- Fixes issue where image styles (e.g., cyberpunk) were not applied during upload

## Test

<img width="1901" height="930" alt="image" src="https://github.com/user-attachments/assets/7db25cad-3245-4aeb-acc0-5b771c48ea00" />
