### PR TITLE
fix: disable when connected brand 0

### DIFF
--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -106,7 +106,7 @@ export function Sidebar({
         <div className="flex-shrink-0 p-6 border-t border-gray-100">
           <Button
             onClick={onGeneratePortrait}
-            disabled={isGenerating}
+            disabled={isGenerating || connectedBrands.length === 0}
             size="lg"
             className="w-full"
           >


### PR DESCRIPTION
## Tests

Goodreads connected

<img width="421" height="776" alt="image" src="https://github.com/user-attachments/assets/f16614f1-5626-4915-8293-2f2a9ee3c675" />

No one connected

<img width="430" height="734" alt="image" src="https://github.com/user-attachments/assets/2d810ee4-cf0e-4903-bf86-5b939dfc6615" />
