### PR TITLE
Prevent SignInDialog from closing during sign-in process

### DIFF
--- a/src/client/components/SignInDialog.tsx
+++ b/src/client/components/SignInDialog.tsx
@@ -86,6 +86,21 @@ export function SignInDialog({
     setCredentials(initial);
   }, [isOpen, brandConfig]);
 
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    // Prevent dialog from closing via ESC key when sign-in process is active
+    const handleCancel = (e: Event) => {
+      if (loadingState) {
+        e.preventDefault();
+      }
+    };
+
+    dialog.addEventListener('cancel', handleCancel);
+    return () => dialog.removeEventListener('cancel', handleCancel);
+  }, [loadingState]);
+
   const pollSigninStatus = async () => {
     if (!signinData) return;
 
@@ -195,7 +210,7 @@ export function SignInDialog({
     >
       <div
         className="fixed inset-0 flex items-center justify-center p-4"
-        onClick={onClose}
+        onClick={loadingState ? undefined : onClose}
         style={{ zIndex: 0 }}
       >
         <div


### PR DESCRIPTION
## Summary
- Prevents the SignInDialog from being closed via ESC key or backdrop click when the sign-in process is loading
- Adds a useEffect to handle the 'cancel' event and conditionally disables the backdrop click

This improves the user experience by avoiding interruption of the authentication flow.

## Tests

Can be close no loading state

https://github.com/user-attachments/assets/fa73b918-0b40-46e0-b988-67b0fa30adc8

Can't be close on loading state

https://github.com/user-attachments/assets/c1ada34e-550c-4240-953e-e3e3985faf6a



