### PR TITLE
feat: collapsible data connector list

### DIFF
--- a/src/client/components/DataConnectors.tsx
+++ b/src/client/components/DataConnectors.tsx
@@ -1,6 +1,8 @@
-import { CheckCircle2 } from 'lucide-react';
+import { useState } from 'react';
+import { CheckCircle2, ChevronDown, ChevronUp } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert.js';
 import { Badge } from '@/components/ui/badge.js';
+import { Button } from '@/components/ui/button.js';
 import { DataSource } from './DataSource.js';
 import type { BrandConfig } from '../modules/Config.js';
 import type { PurchaseHistory } from '../modules/DataTransformSchema.js';
@@ -12,12 +14,23 @@ type DataConnectorsProps = {
   onOpenSignInDialog: (brandConfig: BrandConfig) => void;
 };
 
+const ITEMS_PER_ROW = 3;
+
 export function DataConnectors({
   brands,
   connectedBrands,
   onSuccessConnect,
   onOpenSignInDialog,
 }: DataConnectorsProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const visibleBrands = isExpanded ? brands : brands.slice(0, ITEMS_PER_ROW);
+  const hasMoreBrands = brands.length > ITEMS_PER_ROW;
+
+  const onToggleExpand = () => {
+    setIsExpanded(!isExpanded);
+  };
+
   return (
     <>
       {/* Data Connection Status Alert */}
@@ -62,7 +75,7 @@ export function DataConnectors({
         </div>
 
         <div className="grid grid-cols-3 gap-2">
-          {brands.map((brandConfig) => (
+          {visibleBrands.map((brandConfig) => (
             <DataSource
               key={brandConfig.brand_id}
               brandConfig={brandConfig}
@@ -74,6 +87,29 @@ export function DataConnectors({
             />
           ))}
         </div>
+
+        {hasMoreBrands && (
+          <div className="flex justify-center mt-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onToggleExpand}
+              className="flex items-center gap-2"
+            >
+              {isExpanded ? (
+                <>
+                  <ChevronUp className="h-4 w-4" />
+                  Show Less Connectors
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-4 w-4" />
+                  Show More Connectors ({brands.length - ITEMS_PER_ROW} more)
+                </>
+              )}
+            </Button>
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -124,7 +124,11 @@ export function Sidebar({
         <div className="flex-shrink-0 p-6 border-t border-gray-100">
           <Button
             onClick={onGeneratePortrait}
-            disabled={isGenerating || connectedBrands.length === 0 || selectedItemsCount === 0}
+            disabled={
+              isGenerating ||
+              connectedBrands.length === 0 ||
+              selectedItemsCount === 0
+            }
             size="lg"
             className="w-full"
           >


### PR DESCRIPTION
Modified data connector component to be collapsible when connector list are more than single row. The idea of this is to improve user visibility about image format selector, not hidden under scroll. This will make user aware that they can generate in insta story format as well.

<img width="2692" height="2040" alt="Firefox Developer Edition 2026-02-13 17 40 19" src="https://github.com/user-attachments/assets/59cbf1ca-8aab-46ed-848a-eab18b7d8090" />
<img width="2692" height="2040" alt="Firefox Developer Edition 2026-02-13 17 41 43" src="https://github.com/user-attachments/assets/ddfc46aa-d864-410d-b127-761a9ea9575d" />
<img width="2692" height="2040" alt="Firefox Developer Edition 2026-02-13 17 41 49" src="https://github.com/user-attachments/assets/a767f953-93b5-4477-ad78-b87da7d79f3b" />

