### PR TITLE
feat(goodreads): extract book list via CDP after sign-in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "lucide-react": "^0.522.0",
         "multer": "^2.0.2",
         "nanoid": "^5.1.5",
+        "playwright-core": "^1.61.1",
         "portkey-ai": "^3.0.1",
         "prettier": "^3.5.3",
         "react": "^19.1.0",
@@ -7694,10 +7695,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.53.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
-      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
-      "dev": true,
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -7719,6 +7719,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
+      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portkey-ai": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lucide-react": "^0.522.0",
     "multer": "^2.0.2",
     "nanoid": "^5.1.5",
+    "playwright-core": "^1.61.1",
     "portkey-ai": "^3.0.1",
     "prettier": "^3.5.3",
     "react": "^19.1.0",

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -10,6 +10,10 @@ const enabledFeatures = (process.env.ENABLE_FEATURES || '')
 
 export const settings = {
   GETGATHER_URL: process.env.GETGATHER_URL || '',
+  // Chrome Fleet base URL used for direct CDP access after sign-in.
+  // Defaults to GETGATHER_URL (CDP relayed through mcp-getgather) when unset.
+  GETGATHER_CDP_URL:
+    process.env.GETGATHER_CDP_URL || process.env.GETGATHER_URL || '',
   GETGATHER_APP_KEY: process.env.GETGATHER_APP_KEY || '',
   MAXMIND_ACCOUNT_ID: process.env.MAXMIND_ACCOUNT_ID || '',
   MAXMIND_LICENSE_KEY: process.env.MAXMIND_LICENSE_KEY || '',

--- a/src/server/handlers/mcp-handler.ts
+++ b/src/server/handlers/mcp-handler.ts
@@ -4,6 +4,7 @@ import { mcpClientManager } from '../mcp-client.js';
 import { geolocationService } from '../services/geolocation-service.js';
 import { analytics } from '../services/analytics-service.js';
 import { finalizeSignin } from '../services/mcp-service.js';
+import { extractGoodreadsViaCDP } from '../services/cdp-service.js';
 import { settings } from '../config.js';
 import { getAppHost } from '../utils/index.js';
 import { ServerLogger as Logger } from '../utils/logger/index.js';
@@ -345,12 +346,24 @@ export const handleDpageSigninCheck = async (req: Request, res: Response) => {
     return;
   }
 
-  // Sign-in complete — call the brand tool again to fetch data
+  // Sign-in complete — fetch data.
   const brand = brandTools[brandId];
   let content: unknown[] | null = null;
   let dataFetchOk = false;
 
-  if (brand) {
+  if (brandId === 'goodreads') {
+    // Sign-in stays on mcp-getgather, but we extract the data ourselves by
+    // attaching to the authenticated remote browser over CDP. No fallback —
+    // any failure propagates to a 500.
+    const books = await extractGoodreadsViaCDP({
+      cdpUrl: settings.GETGATHER_CDP_URL,
+      signinId: linkId,
+      sessionId: req.sessionID,
+      clientIp,
+    });
+    content = books;
+    dataFetchOk = true;
+  } else if (brand) {
     try {
       const dataResult = await mcpClient.callTool({ name: brand.toolName }, 0);
       Logger.debug('Brand tool response', {
@@ -416,6 +429,9 @@ export const handleDpageSigninCheck = async (req: Request, res: Response) => {
   res.json({
     auth_completed: true,
     link_id: linkId,
+    // Echo the fleet browser id (prefix of the signin_id) for easy debugging:
+    // it names the browser on the fleet and is the CDP path segment.
+    browser_id: linkId.split('--')[0],
     content,
   });
 };

--- a/src/server/services/cdp-service.ts
+++ b/src/server/services/cdp-service.ts
@@ -1,0 +1,195 @@
+import { chromium, type Browser } from 'playwright-core';
+import { ServerLogger as Logger } from '../utils/logger/index.js';
+import { settings } from '../config.js';
+
+const GOODREADS_ORIGIN = 'https://www.goodreads.com';
+const GOODREADS_BOOK_LIST_URL = `${GOODREADS_ORIGIN}/review/list?ref=nav_mybooks&view=table`;
+
+// How long to wait for the review table to appear after navigation.
+const BOOK_LIST_SELECTOR_TIMEOUT_MS = 30_000;
+
+/**
+ * Book record extracted from the Goodreads review list. Keys mirror the
+ * mcp-getgather distillation pattern (getgather/mcp/patterns/goodreads-booklist.json)
+ * so the result is a drop-in replacement for the `goodreads_book_list` tool output.
+ */
+export interface GoodreadsBook {
+  title: string | null;
+  author: string | null;
+  rating: string | null;
+  url: string | null;
+  cover: string | null;
+  shelf: string | null;
+  added_date: string | null;
+}
+
+/**
+ * Derive the CDP WebSocket base from the (http/https) Chrome Fleet URL.
+ * `https://host` -> `wss://host`, `http://host` -> `ws://host`.
+ */
+function toCdpWebSocketBase(cdpUrl: string): string {
+  return cdpUrl.replace(/^http(s?):\/\//, 'ws$1://').replace(/\/+$/, '');
+}
+
+/**
+ * Build the WebSocket handshake headers, mirroring the MCP client
+ * (src/server/mcp-client.ts). The `/cdp/{browser_id}` route is not behind MCP
+ * auth, but an upstream proxy may still require these, so we always send them.
+ */
+function buildCdpHeaders(sessionId: string, clientIp: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'x-getgather-custom-app': 'data-portrait',
+    'x-origin-ip': clientIp,
+  };
+
+  if (settings.GETGATHER_APP_KEY) {
+    headers['Authorization'] = `Bearer ${settings.GETGATHER_APP_KEY}_${sessionId}`;
+  }
+
+  return headers;
+}
+
+/**
+ * In-page scraper. Runs inside the authenticated Goodreads tab (via
+ * page.evaluate) and replicates the columns from
+ * getgather/mcp/patterns/goodreads-booklist.json.
+ *
+ * NOTE: this is built as a plain string, not a function reference, on purpose.
+ * tsx/esbuild rewrites named functions with a `__name` keepNames helper; when
+ * Playwright serializes a function to run in the browser, that helper is
+ * undefined there (`ReferenceError: __name is not defined`). A string is opaque
+ * to esbuild, so it runs verbatim in the page.
+ */
+function buildScraperScript(origin: string): string {
+  return `
+    (() => {
+      const origin = ${JSON.stringify(origin)};
+      const text = (el) => (el ? (el.textContent || '').trim() || null : null);
+      const attr = (el, name) => {
+        if (!el) return null;
+        const value = el.getAttribute(name);
+        return value ? value.trim() : null;
+      };
+      const rows = Array.from(document.querySelectorAll('tr.review'));
+      return rows.map((row) => {
+        const rawUrl = attr(row.querySelector('td.cover a'), 'href');
+        let url = rawUrl;
+        if (rawUrl) {
+          try { url = new URL(rawUrl, origin).href; } catch (e) { url = rawUrl; }
+        }
+        return {
+          title: attr(row.querySelector('td.title > div > a'), 'title'),
+          author: text(row.querySelector('td.author > div > a')),
+          rating: text(row.querySelector('td.avg_rating > div')),
+          url: url,
+          cover: attr(row.querySelector('td.cover img'), 'src'),
+          shelf: text(row.querySelector('td.shelves a.shelfLink')),
+          added_date: attr(row.querySelector('td.date_added span'), 'title'),
+        };
+      });
+    })()
+  `;
+}
+
+/**
+ * Attach to the already-authenticated remote browser (identified by the
+ * browser_id embedded in the sign-in id) over CDP and extract the Goodreads
+ * book list directly, rather than round-tripping through the MCP tool.
+ *
+ * Throws on any failure — callers should surface the error (no silent fallback).
+ */
+export async function extractGoodreadsViaCDP({
+  cdpUrl,
+  signinId,
+  sessionId,
+  clientIp,
+}: {
+  cdpUrl: string;
+  signinId: string;
+  sessionId: string;
+  clientIp: string;
+}): Promise<GoodreadsBook[]> {
+  // SignInId = "{browser_id}--{target_id}--{mcp_session_id}"
+  // (mcp-getgather/getgather/mcp/dpage.py). We only need browser_id here.
+  const browserId = signinId.split('--')[0];
+  if (!browserId) {
+    throw new Error(`Cannot derive browser_id from signin_id: ${signinId}`);
+  }
+
+  const wsUrl = `${toCdpWebSocketBase(cdpUrl)}/cdp/${browserId}`;
+  const headers = buildCdpHeaders(sessionId, clientIp);
+
+  Logger.info('Extracting Goodreads book list via CDP', {
+    component: 'cdp-service',
+    operation: 'extract-goodreads',
+    brandId: 'goodreads',
+    signinId,
+    browserSessionId: browserId,
+    wsUrl,
+  });
+
+  let browser: Browser | null = null;
+  try {
+    browser = await chromium.connectOverCDP(wsUrl, { headers });
+
+    // Reuse the existing (authenticated) context; a new tab shares its cookies.
+    const context = browser.contexts()[0];
+    if (!context) {
+      throw new Error('No browser context available on the remote browser');
+    }
+
+    // mcp-getgather's CDP proxy namespaces target ids as `browser_id@target_id`,
+    // which breaks Playwright's target tracking on `newPage()`. The authenticated
+    // sign-in browser always has a page open, so reuse it and navigate that tab
+    // (cookies are context-level, so any page in the context is authenticated).
+    const existingPages = context.pages();
+    const page =
+      existingPages.length > 0 ? existingPages[0] : await context.newPage();
+    try {
+      await page.goto(GOODREADS_BOOK_LIST_URL, { waitUntil: 'domcontentloaded' });
+
+      try {
+        await page.waitForSelector('tr.review', {
+          timeout: BOOK_LIST_SELECTOR_TIMEOUT_MS,
+        });
+      } catch {
+        // No rows rendered — treat as an empty (but valid) book list.
+        Logger.warn('No Goodreads review rows found', {
+          component: 'cdp-service',
+          operation: 'extract-goodreads',
+          browserSessionId: browserId,
+        });
+        return [];
+      }
+
+      const books = (await page.evaluate(
+        buildScraperScript(GOODREADS_ORIGIN)
+      )) as GoodreadsBook[];
+
+      Logger.info('Goodreads book list extracted via CDP', {
+        component: 'cdp-service',
+        operation: 'extract-goodreads',
+        browserSessionId: browserId,
+        bookCount: books.length,
+      });
+
+      return books;
+    } finally {
+      await page.close().catch(() => {});
+    }
+  } catch (error) {
+    Logger.error('CDP extraction failed', error as Error, {
+      component: 'cdp-service',
+      operation: 'extract-goodreads',
+      browserSessionId: browserId,
+      wsUrl,
+    });
+    throw error;
+  } finally {
+    // For connectOverCDP, close() disconnects the CDP session without
+    // terminating the remote browser, so finalize_signin still owns teardown.
+    if (browser) {
+      await browser.close().catch(() => {});
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Splits Goodreads data extraction from sign-in. **Sign-in stays on mcp-getgather** (the interactive dpage flow, unchanged), but once the user is authenticated we **attach to the remote browser over CDP from data-portrait** and scrape the reading list ourselves — instead of round-tripping through the `goodreads_get_book_list` MCP tool. This gives us direct control over extraction (selectors, pagination, future per-brand logic).

This works because the `signin_id` data-portrait already receives is a composite `"{browser_id}--{target_id}--{mcp_session_id}"`, so `browser_id = signin_id.split('--')[0]` is exactly the handle needed to attach via CDP.

Scope: **Goodreads only**. Transport: Playwright `connectOverCDP`. **No fallback** — if CDP extraction fails, the error surfaces (500), it does not silently fall back to the MCP tool.

## How it works

1. `handleDpageSigninCheck` polls `check_signin`; on `SUCCESS` for Goodreads it calls `extractGoodreadsViaCDP()` instead of the tool.
2. The extractor connects Playwright to `${GETGATHER_CDP_URL}/cdp/{browser_id}`, reuses the authenticated page, navigates to the review-list table, and scrapes the columns from mcp-getgather's `goodreads-booklist` pattern (`title`, `author`, `rating`, `url`, `cover`, `shelf`, `added_date`).
3. Output shape is a drop-in match for the old tool output (array with `title`/`cover`), so the client `transformData` pipeline is unchanged.
4. `finalize_signin` still owns browser teardown.

## Config

New `GETGATHER_CDP_URL` env var — the Chrome Fleet host can differ from the MCP/sign-in host. Defaults to `GETGATHER_URL` (relaying CDP through mcp-getgather) when unset.

- `GETGATHER_URL` → mcp-getgather (MCP tools + `/dpage`)
- `GETGATHER_CDP_URL` → Chrome Fleet (`/cdp/{browser_id}`)

## Fleet-specific gotchas found while testing (documented in code)

- **Target-id namespacing:** the fleet's CDP proxy prefixes target ids as `browser_id@target_id`, which breaks Playwright's `newPage()`. The extractor reuses the existing authenticated page instead.
- **`__name is not defined`:** esbuild/tsx's `keepNames` helper is undefined in the browser, so the in-page scraper is passed as a plain string, not a function reference.
- **`browser.close()`** on a `connectOverCDP` connection only disconnects CDP; it does not terminate the remote browser.

## Verification

Verified end-to-end against a live fleet: attached to a real authenticated Goodreads session over CDP and extracted **20 books** with all seven fields populated (`title`/`cover` present for `transformData`).




🤖 Generated with [Claude Code](https://claude.com/claude-code)