### PR TITLE
feat: migrate sign-in to REST distill flow (officedepot, wayfair, gofood, garmin)

### DIFF
--- a/src/client/components/DpageConnectionModal.tsx
+++ b/src/client/components/DpageConnectionModal.tsx
@@ -5,7 +5,7 @@ import { toPurchaseHistory } from '../modules/DataTransformSchema.js';
 import { logger } from '@/utils/logger/index.js';
 import { Button } from '@/components/ui/button.js';
 
-type GoodreadsConnectionModalProps = {
+type DpageConnectionModalProps = {
   isOpen: boolean;
   onClose: () => void;
   onSuccessConnect: (data: PurchaseHistory[]) => void;
@@ -16,12 +16,12 @@ type BrowserTarget = { browserId: string; pageId: string };
 
 const POLL_INTERVAL_MS = 3000;
 
-export function GoodreadsConnectionModal({
+export function DpageConnectionModal({
   isOpen,
   onClose,
   onSuccessConnect,
   brandConfig,
-}: GoodreadsConnectionModalProps) {
+}: DpageConnectionModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [target, setTarget] = useState<BrowserTarget | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -53,16 +53,19 @@ export function GoodreadsConnectionModal({
 
     (async () => {
       try {
-        const res = await fetch('/getgather/goodreads/connect', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        });
+        const res = await fetch(
+          `/getgather/dpage/${brandConfig.brand_id}/connect`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = (await res.json()) as BrowserTarget;
         setTarget(data);
       } catch (err) {
-        logger.error('Failed to start Goodreads connection', err as Error, {
-          component: 'goodreads-connection-modal',
+        logger.error('Failed to start connection', err as Error, {
+          component: 'dpage-connection-modal',
           brandId: brandConfig.brand_id,
         });
         setError('Failed to start connection. Please try again.');
@@ -79,11 +82,14 @@ export function GoodreadsConnectionModal({
     (async () => {
       while (!stopped) {
         try {
-          const res = await fetch('/getgather/goodreads/poll', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ browser_id: browserId, page_id: pageId }),
-          });
+          const res = await fetch(
+            `/getgather/dpage/${brandConfig.brand_id}/poll`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ browser_id: browserId, page_id: pageId }),
+            }
+          );
           if (res.ok) {
             const data = (await res.json()) as {
               status?: string;
@@ -97,17 +103,23 @@ export function GoodreadsConnectionModal({
               stopped = true;
               callbacks.current.onSuccessConnect(purchaseHistory);
               callbacks.current.onClose();
-              void fetch('/getgather/goodreads/finalize', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ browser_id: browserId, page_id: pageId }),
-              });
+              void fetch(
+                `/getgather/dpage/${brandConfig.brand_id}/finalize`,
+                {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    browser_id: browserId,
+                    page_id: pageId,
+                  }),
+                }
+              );
               return;
             }
           }
         } catch (err) {
-          logger.error('Goodreads poll error', err as Error, {
-            component: 'goodreads-connection-modal',
+          logger.error('dpage poll error', err as Error, {
+            component: 'dpage-connection-modal',
             brandId: brandConfig.brand_id,
           });
         }
@@ -159,7 +171,7 @@ export function GoodreadsConnectionModal({
             </div>
           ) : target ? (
             <iframe
-              src={`/getgather/dpage/${target.browserId}/${target.pageId}`}
+              src={`/getgather/dpage/frame/${target.browserId}/${target.pageId}`}
               sandbox="allow-same-origin allow-scripts allow-forms"
               title={`${brandConfig.brand_name} sign in`}
               className="w-full h-[420px] rounded-xl border border-gray-200"

--- a/src/client/config/garmin.json
+++ b/src/client/config/garmin.json
@@ -4,6 +4,7 @@
   "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a6/Garmin_logo_2006.svg",
   "is_mandatory": false,
   "is_dpage": true,
+  "use_dpage_iframe": true,
   "schema": [
     {
       "name": "email",

--- a/src/client/config/gofood.json
+++ b/src/client/config/gofood.json
@@ -4,6 +4,7 @@
   "logo_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Gofood_logo.svg/1280px-Gofood_logo.svg.png",
   "is_mandatory": false,
   "is_dpage": true,
+  "use_dpage_iframe": true,
   "schema": [
     {
       "name": "phone",

--- a/src/client/config/officedepot.json
+++ b/src/client/config/officedepot.json
@@ -2,6 +2,9 @@
   "brand_id": "officedepot",
   "brand_name": "Office Depot",
   "logo_url": "https://upload.wikimedia.org/wikipedia/commons/e/e3/Office-depot-logo.png",
+  "is_mandatory": false,
+  "is_dpage": true,
+  "use_dpage_iframe": true,
   "dataTransform": {
     "dataPath": "bundles.1.content",
     "fieldMappings": [

--- a/src/client/config/wayfair.json
+++ b/src/client/config/wayfair.json
@@ -4,6 +4,7 @@
   "logo_url": "https://upload.wikimedia.org/wikipedia/commons/0/0a/Wayfair_logo_with_tagline.png",
   "is_mandatory": false,
   "is_dpage": true,
+  "use_dpage_iframe": true,
   "dataTransform": {
     "dataPath": "data.orderProductPagesByCustomer.nodes",
     "fieldMappings": [

--- a/src/client/modules/Config.ts
+++ b/src/client/modules/Config.ts
@@ -8,7 +8,7 @@ export type BrandConfig = {
   is_mandatory: boolean;
   is_dpage?: boolean;
   /**
-   * Use the iframe-based distill sign-in flow (GoodreadsConnectionModal) instead
+   * Use the iframe-based distill sign-in flow (DpageConnectionModal) instead
    * of the credential-form + MCP flow (SignInDialog). Opt in per brand via config
    * so the page never branches on a brand id.
    */

--- a/src/client/modules/DataTransformSchema.ts
+++ b/src/client/modules/DataTransformSchema.ts
@@ -95,6 +95,18 @@ export function parseOrderDate(orderDateStr: string) {
     return new Date(`${month} ${day}, ${currentYear}`);
   }
 
+  // Handle Garmin's /app format: month-first "Mar 15", "Mar 15 2026", or
+  // "Mar 152026" (day + year concatenated, since the year lives in an adjacent
+  // span with no separator). Year is optional and defaults to the current year.
+  const garminMonthFirst = orderDateStr.match(
+    /^([A-Za-z]{3,})\s+(\d{1,2})\s*(\d{4})?$/
+  );
+  if (garminMonthFirst) {
+    const [, month, day, year] = garminMonthFirst;
+    const resolvedYear = year || String(new Date().getFullYear());
+    return new Date(`${month} ${day}, ${resolvedYear}`);
+  }
+
   return null;
 }
 

--- a/src/client/pages/DataPortrait.tsx
+++ b/src/client/pages/DataPortrait.tsx
@@ -8,7 +8,7 @@ import { GeneratedImagesGrid } from '../components/GeneratedImagesGrid.js';
 import { ImagePreviewModal } from '../components/ImagePreviewModal.js';
 import { StoryPreviewModal } from '../components/StoryPreviewModal.js';
 import { SignInDialog } from '../components/SignInDialog.js';
-import { GoodreadsConnectionModal } from '../components/GoodreadsConnectionModal.js';
+import { DpageConnectionModal } from '../components/DpageConnectionModal.js';
 import { Sidebar } from '../components/Sidebar.js';
 import amazon from '../config/amazon.json' with { type: 'json' };
 import wayfair from '../config/wayfair.json' with { type: 'json' };
@@ -485,11 +485,11 @@ export function DataPortrait() {
       />
 
       {/* Sign In Dialog — brands opting into the iframe dpage flow (config
-          `use_dpage_iframe`) use GoodreadsConnectionModal; others use the
+          `use_dpage_iframe`) use DpageConnectionModal; others use the
           credential-form + MCP flow. */}
       {signInDialogBrand &&
         (signInDialogBrand.use_dpage_iframe ? (
-          <GoodreadsConnectionModal
+          <DpageConnectionModal
             isOpen={true}
             onClose={() => setSignInDialogBrand(null)}
             onSuccessConnect={handleSignInSuccess}

--- a/src/server/handlers/dpage-handler.ts
+++ b/src/server/handlers/dpage-handler.ts
@@ -51,6 +51,37 @@ function loadingPage(extraBody = ''): string {
 </html>`;
 }
 
+// A styled error page for the iframe, shown when distillation reaches a dead
+// end (matched a page but produced neither data nor a form to fill).
+function errorPage(message: string): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="${DPAGE_CSS}" />
+  </head>
+  <body>
+    <div class="content-wrapper">
+      <p>${message}</p>
+    </div>
+  </body>
+</html>`;
+}
+
+// A real sign-in / verification step has fields to fill (email, password, OTP).
+// A distilled *data* page (signed in) has none — only content/buttons. We use
+// the presence of form inputs to tell "render this form" from "distill produced
+// no usable data", so stale data selectors surface as an error, not a blank/dump.
+function hasSignInFields(html: string): boolean {
+  try {
+    const { document } = parseHTML(html);
+    return document.querySelectorAll('input, select, textarea').length > 0;
+  } catch {
+    return false;
+  }
+}
+
 // Browsers can't redirect from a GET to a POST, so serve an auto-submitting form.
 function redirect(action: string): string {
   return loadingPage(
@@ -197,8 +228,27 @@ export const handleDpageFramePost = async (req: Request, res: Response) => {
     if (json) {
       // Data is ready; show a spinner until the client's poll grabs it.
       res.type('text/html').send(loadingPage());
-    } else {
+    } else if (hasSignInFields(html)) {
+      // Still a sign-in / verification step to complete.
       res.type('text/html').send(formatDistilledPage(html, browserId, pageId));
+    } else {
+      // Distill matched a page but produced no structured data and no form to
+      // fill — typically signed in but the data selectors are stale. Surface an
+      // explicit error instead of dumping raw HTML into the modal (which reads
+      // as a blank/garbled dialog).
+      Logger.warn('dpage distill produced no data and no sign-in fields', {
+        component: 'dpage-handler',
+        operation: 'frame',
+        browserSessionId: browserId,
+        pageId,
+      });
+      res
+        .type('text/html')
+        .send(
+          errorPage(
+            "We couldn't read your data right now. Please try connecting again later."
+          )
+        );
     }
   } catch (error) {
     Logger.error('dpage step failed', error as Error, {

--- a/src/server/handlers/dpage-handler.ts
+++ b/src/server/handlers/dpage-handler.ts
@@ -12,8 +12,15 @@ import {
   readDistilledOnce,
 } from '../services/remotebrowser.js';
 
-const GOODREADS_REVIEW_LIST_URL =
-  'https://www.goodreads.com/review/list?ref=nav_mybooks&view=table';
+// Brands that use the iframe distill sign-in flow. The value is the data URL we
+// navigate the remote browser to: getgather's distiller matches a pattern by
+// hostname on whatever page results (the sign-in form when logged out, the data
+// when logged in), so a single URL drives the whole flow. To onboard another
+// brand, add its data URL here and set `use_dpage_iframe: true` in its config.
+const BRAND_DPAGE_URLS: Record<string, string> = {
+  goodreads: 'https://www.goodreads.com/review/list?ref=nav_mybooks&view=table',
+  officedepot: 'https://www.officedepot.com/orderhistory/orderHistoryList.do',
+};
 
 // The distilled sign-in form is served in the modal iframe; these assets are
 // served from data-portrait's public/ dir (Vite in dev, express.static in prod).
@@ -76,7 +83,7 @@ function formatDistilledPage(
 
   const form = document.createElement('form');
   form.setAttribute('method', 'POST');
-  form.setAttribute('action', `/getgather/dpage/${browserId}/${pageId}`);
+  form.setAttribute('action', `/getgather/dpage/frame/${browserId}/${pageId}`);
 
   const body = document.body;
   while (body.firstChild) {
@@ -93,7 +100,7 @@ function formatDistilledPage(
 
 /**
  * Advance the distillation loop, then read the distilled page once: the
- * book-list JSON if it's ready, otherwise the sign-in form HTML.
+ * structured data JSON if it's ready, otherwise the sign-in form HTML.
  */
 async function initiateDistill(
   browserId: string,
@@ -119,44 +126,55 @@ function browserCreateHeaders(req: Request): Record<string, string | undefined> 
   return headers;
 }
 
-// POST /getgather/goodreads/connect — create a fresh browser and open the review list.
-export const handleGoodreadsConnect = async (req: Request, res: Response) => {
+// POST /getgather/dpage/:brandId/connect — create a fresh browser and open the
+// brand's data URL (which surfaces the sign-in form when logged out).
+export const handleDpageConnect = async (req: Request, res: Response) => {
+  const { brandId } = req.params;
+  const dataUrl = BRAND_DPAGE_URLS[brandId];
+  if (!dataUrl) {
+    res.status(400).json({ error: `Unsupported dpage brand: ${brandId}` });
+    return;
+  }
+
   try {
     const headers = browserCreateHeaders(req);
     const { browserId, pageId } = await prepareNewBrowser(headers);
-    await navigatePage(browserId, pageId, GOODREADS_REVIEW_LIST_URL);
+    await navigatePage(browserId, pageId, dataUrl);
 
-    Logger.info('Goodreads dpage browser ready', {
-      component: 'goodreads-handler',
+    Logger.info('dpage browser ready', {
+      component: 'dpage-handler',
       operation: 'connect',
-      brandId: 'goodreads',
+      brandId,
       browserSessionId: browserId,
       pageId,
     });
 
     res.json({ browserId, pageId });
   } catch (error) {
-    Logger.error('Goodreads connect failed', error as Error, {
-      component: 'goodreads-handler',
+    Logger.error('dpage connect failed', error as Error, {
+      component: 'dpage-handler',
       operation: 'connect',
+      brandId,
     });
-    res.status(500).json({ error: 'Failed to start Goodreads connection' });
+    res.status(500).json({ error: `Failed to start ${brandId} connection` });
   }
 };
 
-// GET /getgather/dpage/:browserId/:pageId — iframe entry; auto-POSTs to itself.
-export const handleGoodreadsDpageGet = (req: Request, res: Response) => {
+// GET /getgather/dpage/frame/:browserId/:pageId — iframe entry; auto-POSTs to itself.
+export const handleDpageFrameGet = (req: Request, res: Response) => {
   const { browserId, pageId } = req.params;
   if (!browserId || !pageId) {
     res.status(400).send();
     return;
   }
-  res.type('text/html').send(redirect(`/getgather/dpage/${browserId}/${pageId}`));
+  res
+    .type('text/html')
+    .send(redirect(`/getgather/dpage/frame/${browserId}/${pageId}`));
 };
 
-// POST /getgather/dpage/:browserId/:pageId — drive one distill step; return the
-// next distilled form (HTML) or a spinner once the data is ready.
-export const handleGoodreadsDpagePost = async (req: Request, res: Response) => {
+// POST /getgather/dpage/frame/:browserId/:pageId — drive one distill step; return
+// the next distilled form (HTML) or a spinner once the data is ready.
+export const handleDpageFramePost = async (req: Request, res: Response) => {
   const { browserId, pageId } = req.params;
   if (!browserId || !pageId) {
     res.status(400).send();
@@ -179,9 +197,9 @@ export const handleGoodreadsDpagePost = async (req: Request, res: Response) => {
       res.type('text/html').send(formatDistilledPage(html, browserId, pageId));
     }
   } catch (error) {
-    Logger.error('Goodreads dpage step failed', error as Error, {
-      component: 'goodreads-handler',
-      operation: 'dpage',
+    Logger.error('dpage step failed', error as Error, {
+      component: 'dpage-handler',
+      operation: 'frame',
       browserSessionId: browserId,
       pageId,
     });
@@ -189,8 +207,8 @@ export const handleGoodreadsDpagePost = async (req: Request, res: Response) => {
   }
 };
 
-// POST /getgather/goodreads/poll — return the book list once distillation yields JSON.
-export const handleGoodreadsPoll = async (req: Request, res: Response) => {
+// POST /getgather/dpage/:brandId/poll — return the distilled data once sign-in completes.
+export const handleDpagePoll = async (req: Request, res: Response) => {
   const { browser_id: browserId, page_id: pageId } = (req.body ?? {}) as {
     browser_id?: string;
     page_id?: string;
@@ -200,9 +218,9 @@ export const handleGoodreadsPoll = async (req: Request, res: Response) => {
     return;
   }
 
-  // Single, fast read: if the distilled page isn't the book-list JSON yet
-  // (still on the sign-in / verification form, or not ready), stay PENDING and
-  // let the client's poll interval drive the retry — don't hold the request open.
+  // Single, fast read: if the distilled page isn't the data JSON yet (still on
+  // the sign-in / verification form, or not ready), stay PENDING and let the
+  // client's poll interval drive the retry — don't hold the request open.
   const distilled = await readDistilledOnce(browserId, pageId);
   const content = distilled?.json ?? [];
   const status = content.length > 0 ? 'SUCCESS' : 'PENDING';
@@ -210,8 +228,8 @@ export const handleGoodreadsPoll = async (req: Request, res: Response) => {
   res.json({ status, content });
 };
 
-// POST /getgather/goodreads/finalize — tear down the remote browser.
-export const handleGoodreadsFinalize = async (req: Request, res: Response) => {
+// POST /getgather/dpage/:brandId/finalize — tear down the remote browser.
+export const handleDpageFinalize = async (req: Request, res: Response) => {
   const { browser_id: browserId } = (req.body ?? {}) as { browser_id?: string };
   if (!browserId) {
     res.status(400).json({ error: 'browser_id is required' });

--- a/src/server/handlers/dpage-handler.ts
+++ b/src/server/handlers/dpage-handler.ts
@@ -20,6 +20,10 @@ import {
 const BRAND_DPAGE_URLS: Record<string, string> = {
   goodreads: 'https://www.goodreads.com/review/list?ref=nav_mybooks&view=table',
   officedepot: 'https://www.officedepot.com/orderhistory/orderHistoryList.do',
+  wayfair:
+    'https://www.wayfair.com/session/secure/account/order_search.php?page=1',
+  gofood: 'https://gofood.co.id/en/orders',
+  garmin: 'https://connect.garmin.com/modern/activities',
 };
 
 // The distilled sign-in form is served in the modal iframe; these assets are

--- a/src/server/handlers/mcp-handler.ts
+++ b/src/server/handlers/mcp-handler.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from 'express';
-import { z } from 'zod';
 import { mcpClientManager } from '../mcp-client.js';
 import { geolocationService } from '../services/geolocation-service.js';
 import { analytics } from '../services/analytics-service.js';
@@ -11,12 +10,11 @@ import { ServerLogger as Logger } from '../utils/logger/index.js';
 interface BrandTool {
   toolName: string;
   resultKey: string;
-  detailsToolName?: string;
 }
 
 const brandTools: Record<string, BrandTool> = {
   amazon: { toolName: 'amazon_get_purchase_history', resultKey: 'amazon_purchase_history' },
-  officedepot: { toolName: 'officedepot_get_order_history', resultKey: 'officedepot_order_history', detailsToolName: 'officedepot_get_order_history_details' },
+  officedepot: { toolName: 'officedepot_get_order_history', resultKey: 'officedepot_order_history' },
   wayfair: { toolName: 'wayfair_get_order_history', resultKey: 'wayfair_order_history' },
   goodreads: { toolName: 'goodreads_get_book_list', resultKey: 'goodreads_book_list' },
   gofood: { toolName: 'gofood_get_purchase_history', resultKey: 'gofood_purchase_history' },
@@ -27,42 +25,9 @@ const brandTools: Record<string, BrandTool> = {
   youtube: { toolName: 'youtube_get_watch_history', resultKey: 'youtube_watch_history' },
 };
 
-const McpResponse = z.object({
-  // Auth fields
-  url: z.string().optional(),
-  link_id: z.string().optional(),
-  message: z.string().optional(),
-  system_message: z.string().optional(),
-
-  // Data fields
-  extract_result: z
-    .array(
-      z.object({
-        name: z.string(),
-        parsed: z.boolean(),
-        parse_schema: z.record(z.unknown()).nullable(),
-        content: z.string(),
-      })
-    )
-    .optional(),
-  // goodreads response
-  books: z.array(z.record(z.unknown())).optional(),
-  // amazon response
-  purchases: z.array(z.record(z.unknown())).optional(),
-  // officedepot response
-  purchase_history: z.array(z.record(z.unknown())).optional(),
-  purchase_history_details: z.array(z.record(z.unknown())).optional(),
-  doordash_orders: z.array(z.record(z.unknown())).optional(),
-  youtube_watch_history: z.array(z.record(z.unknown())).optional(),
-});
-
 type PurchaseHistoryResponse = {
   link_id: string;
   hosted_link_url: string;
-  content: Array<unknown> | Record<string, unknown>;
-};
-
-type PurchaseHistoryDetailsResponse = {
   content: Array<unknown> | Record<string, unknown>;
 };
 
@@ -177,50 +142,6 @@ export const handlePurchaseHistory = async (req: Request, res: Response) => {
   }
 
   res.json({ link_id: '', hosted_link_url: '', content });
-};
-
-export const handlePurchaseHistoryDetails = async (
-  req: Request,
-  res: Response
-) => {
-  const { brandId, orderId } = req.params;
-  const brand = brandTools[brandId];
-  if (!brand?.detailsToolName) {
-    res.status(400).json({ error: 'Invalid brand name' });
-    return;
-  }
-
-  const clientIp = geolocationService.getClientIp(req);
-  const mcpClient = await mcpClientManager.get({
-    sessionId: req.sessionID,
-    clientIp,
-    brandId,
-  });
-  const result = await mcpClient.callTool({
-    name: brand.detailsToolName,
-    arguments: { order_id: orderId },
-  });
-
-  const mcpResponse = McpResponse.parse(result.structuredContent);
-
-  // if didn't have any content
-  if (!mcpResponse.purchase_history_details?.length) {
-    res.json({});
-    return;
-  }
-
-  const response: PurchaseHistoryDetailsResponse = {
-    content: [],
-  };
-
-  const rawContent = mcpResponse.purchase_history_details;
-  if (typeof rawContent === 'string') {
-    response.content = JSON.parse(rawContent);
-  } else {
-    response.content = rawContent || [];
-  }
-
-  res.json(response);
 };
 
 export const handleMcpPoll = async (req: Request, res: Response) => {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -37,7 +37,7 @@ app.disable('x-powered-by');
 // Basic security headers
 app.use((req, res, next) => {
   // Allow framing for dpage content since it's designed to be embedded
-  // (both the proxied mcp-getgather /dpage and our own Goodreads dpage route).
+  // (both the proxied mcp-getgather /dpage and our own /getgather/dpage routes).
   const isDpageRequest =
     req.path.startsWith('/dpage') || req.path.startsWith('/getgather/dpage');
   if (!isDpageRequest) {

--- a/src/server/routes/api-routes.ts
+++ b/src/server/routes/api-routes.ts
@@ -5,7 +5,6 @@ import { handleGeneratePortrait } from '../handlers/portrait-handler.js';
 import {
   handlePurchaseHistory,
   handleMcpPoll,
-  handlePurchaseHistoryDetails,
   handleDpageUrl,
   handleDpageSigninCheck,
 } from '../handlers/mcp-handler.js';
@@ -58,12 +57,6 @@ router.get('/dpage-signin-check/:brandId/:linkId', handleDpageSigninCheck);
 
 // Get purchase history
 router.get('/purchase-history/:brandId', handlePurchaseHistory);
-
-// Get purchase history details (officedepot only)
-router.get(
-  '/purchase-history-details/:brandId/:orderId',
-  handlePurchaseHistoryDetails
-);
 
 // MCP poll endpoint
 router.get('/mcp-poll/:brandId/:linkId', handleMcpPoll);

--- a/src/server/routes/api-routes.ts
+++ b/src/server/routes/api-routes.ts
@@ -10,12 +10,12 @@ import {
   handleDpageSigninCheck,
 } from '../handlers/mcp-handler.js';
 import {
-  handleGoodreadsConnect,
-  handleGoodreadsDpageGet,
-  handleGoodreadsDpagePost,
-  handleGoodreadsPoll,
-  handleGoodreadsFinalize,
-} from '../handlers/goodreads-handler.js';
+  handleDpageConnect,
+  handleDpageFrameGet,
+  handleDpageFramePost,
+  handleDpagePoll,
+  handleDpageFinalize,
+} from '../handlers/dpage-handler.js';
 import { handleAnalytics } from '../handlers/analytics-handler.js';
 import {
   handleStoriesGeneration,
@@ -40,12 +40,16 @@ const upload = multer({
   },
 });
 
-// Goodreads dpage flow (distill REST API — no MCP)
-router.post('/goodreads/connect', handleGoodreadsConnect);
-router.get('/dpage/:browserId/:pageId', handleGoodreadsDpageGet);
-router.post('/dpage/:browserId/:pageId', handleGoodreadsDpagePost);
-router.post('/goodreads/poll', handleGoodreadsPoll);
-router.post('/goodreads/finalize', handleGoodreadsFinalize);
+// Brand-agnostic iframe dpage flow (distill REST API — no MCP). Brands opt in
+// via `use_dpage_iframe: true` in their config; the server maps brandId -> data
+// URL in dpage-handler. The /frame/ routes serve/advance the iframe form and are
+// keyed by browserId/pageId (a literal "frame" segment keeps them from colliding
+// with the brand-scoped lifecycle routes).
+router.post('/dpage/:brandId/connect', handleDpageConnect);
+router.post('/dpage/:brandId/poll', handleDpagePoll);
+router.post('/dpage/:brandId/finalize', handleDpageFinalize);
+router.get('/dpage/frame/:browserId/:pageId', handleDpageFrameGet);
+router.post('/dpage/frame/:browserId/:pageId', handleDpageFramePost);
 
 // Get dpage url
 router.get('/dpage-url/:brandId', handleDpageUrl);


### PR DESCRIPTION
## Summary

Generalizes the previously Goodreads-only iframe **distill sign-in flow** into a brand-agnostic REST flow, and migrates four brands off the MCP credential-form flow onto it.

Before this, sign-in had two paths: an MCP tool flow (`SignInDialog`) for most brands, and a hardcoded Goodreads-only REST/distill iframe flow. This makes the REST/distill flow reusable and opt-in per brand via config.

<img width="1249" height="651" alt="Screenshot 2026-07-23 at 16 41 19" src="https://github.com/user-attachments/assets/c888d0cf-2d03-493b-bfa2-53fd18032758" />



## What changed

**Generalized the flow**
- `goodreads-handler.ts` → `dpage-handler.ts`: brand-agnostic, driven by a `brandId → data-URL` map (`BRAND_DPAGE_URLS`).
- Routes: `POST /getgather/dpage/:brandId/{connect,poll,finalize}` + `GET|POST /getgather/dpage/frame/:browserId/:pageId` (literal `frame` segment avoids param collisions).
- `GoodreadsConnectionModal.tsx` → `DpageConnectionModal.tsx`: endpoints derived from `brandConfig.brand_id`.
- Brands opt in with `use_dpage_iframe: true` in their config.

**Migrated brands** (config sourcePaths verified to align with getgather's distill converter columns, so distilled rows match what the UI renders):
- OfficeDepot → order history
- Wayfair → order search
- GoFood → orders
- Garmin → activities

**Cleanup**
- Removed the dead `purchase-history-details` MCP feature (OfficeDepot was its only user; no client ever called it) — handler, route, types, zod schema, and the now-unused `zod` import.

## Deferred (not clean single-navigate distill migrations)

| Brand | Reason |
|---|---|
| doordash | Distilled rows group several stores per row; needs `splitDoorDashOrders` post-processing ported into the REST flow — deferred pending more validation |
| amazon | Multi-step OTP / captcha / arkose / verification auth |
| shopee | WhatsApp verification-link login flow |
| tokopedia | Pin-verification step + no transaction converter JSON |
| youtube | Script-based extraction + Google sign-in complexity |

## Verification

- ✅ `npm run typecheck`, `npm run lint`, `npm run build` all pass.
- ⚠️ Not run end-to-end (no running getgather instance + credentials in dev env). Machinery is shared with the already-working Goodreads/OfficeDepot flow and data shapes are verified. The one thing to confirm per brand on a live run: post-login lands back on the data page so `poll` returns rows.